### PR TITLE
Added Support for React Native Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ new MaterialStyledDialog.Builder(this)
 	.show();
 ```
 
+
+## Third Party Bindings
+
+### React Native
+You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-styled-dialogs)
+
+
 ## License
 	Copyright 2016-2018 Javier Santos
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:27.0.1'
-    compile 'com.afollestad.material-dialogs:core:0.9.6.0'
+    compile 'com.github.afollestad:material-dialogs:75aff51216a2f830b4d01b89bcab190a9f9aacc1'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:appcompat-v7:27.0.1'
     compile 'com.afollestad.material-dialogs:core:0.9.6.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.afollestad.material-dialogs:core:0.9.0.2'
+    compile 'com.afollestad.material-dialogs:core:0.9.6.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 11
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "2.1"
     }
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.afollestad.material-dialogs:core:0.9.6.0'
 }


### PR DESCRIPTION
Hi @javiersantos ,

First of all I would like to appreciate for creating such a cool library.

I have created a [React Native](https://github.com/facebook/react-native) bridge plugin for using this library with React Native projects

I have added the same in README. Can you please merge this request so that if someone looking to use this library for React Native projects can easily do the same.

Please let me know in case any changes are required.

[react-native-styled-dialogs](https://github.com/prscX/react-native-styled-dialogs)

Thanks
</ Pranav >